### PR TITLE
Fixed compilation error on Mac OSX

### DIFF
--- a/tomboy/MyDocument.cs
+++ b/tomboy/MyDocument.cs
@@ -104,7 +104,7 @@ namespace Tomboy
 		/// <param name='e'>
 		/// E.
         /// </param>//WebNavigationPolicyEventArgs
-		void HandleWebViewDecidePolicyForNavigation (object sender, WebNavigatioPolicyEventArgs e)
+		void HandleWebViewDecidePolicyForNavigation (object sender, WebNavigationPolicyEventArgs e)
 		{
 			// Reference for examples of this method in use
 			// https://github.com/mono/monomac/commit/efc6e28fc03005638ce2cd217dc6c9281ad9c1c5


### PR DESCRIPTION
The WebNavigationPolicyEventArgs had the "n" missing after WebNavigationPolicyEventArgs. It is fixed now.
