### PR TITLE
Fix Cache location. It should be Caches

### DIFF
--- a/tomboy/AppDelegate.cs
+++ b/tomboy/AppDelegate.cs
@@ -315,7 +315,7 @@ namespace Tomboy
 		public static string BaseUrlPath {
 			get {
 				String SpecialFolderCache = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.Personal),
-				                     "Library", "Cache", "Tomboy");
+				                     "Library", "Caches", "Tomboy");
 				Logger.Debug ("cache directory set to {0}", SpecialFolderCache);
 				return SpecialFolderCache;
 			}


### PR DESCRIPTION
On mac in the Library directory the cache directory
by default is Caches. This seems to by a typo as
Caches is referenced else where.
